### PR TITLE
start covering the case of outward returns

### DIFF
--- a/httperroryzer.go
+++ b/httperroryzer.go
@@ -24,6 +24,7 @@ import (
 	"golang.org/x/tools/go/analysis/passes/ctrlflow"
 	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/cfg"
 )
 
 const Doc = `check for a missing return after invoking http.Error
@@ -85,8 +86,25 @@ func run(pass *analysis.Pass) (interface{}, error) {
 
 		// Great, we've identified that the function takes http.ResponseWriter as an argument!
 		// Let's inspect its control flow graph.
-		cfg := cfgs.FuncDecl(fnDecl)
-		for _, block := range cfg.Blocks {
+		acfg := cfgs.FuncDecl(fnDecl)
+
+		explorable := make(map[int32]bool)
+		for _, block := range acfg.Blocks {
+			explorable[block.Index] = true
+		}
+		// Partition the graph, by deleting the roots accessible by the
+		// entry block, so that the two roots can never be connected.
+		for _, block := range acfg.Blocks[0].Succs {
+			delete(explorable, block.Index)
+		}
+
+		// Now that the roots are deleted, we can build the incidence graph with no more problems.
+		partitionedButConnectedBlocks := make(incidence)
+		for _, block := range acfg.Blocks[0].Succs {
+			buildIncidence(block, explorable, partitionedButConnectedBlocks)
+		}
+
+		for _, block := range acfg.Blocks {
 			if retStmt := block.Return(); retStmt != nil {
 				continue
 			}
@@ -116,16 +134,56 @@ func run(pass *analysis.Pass) (interface{}, error) {
 					break
 				}
 			}
-			// No invocation of http.Error in this block.
+
+			// No invocation of http.Error in this block, can safely continue.
 			if firstHTTPErrorIndex == -1 {
 				continue
 			}
 
-			// Search for a terminating statement from here on until the end of the block.
 			tillEndOfBlock := block.Nodes[firstHTTPErrorIndex+1:]
+			// First attempt is to try to find any terminating statements in the same block as the
+			// http.Error statement, for example:
+			//  if cond {
+			//      http.Error(rw, msg, code)
+			//      ...
+			//      ...
+			//      panic("panicking here")
+			//  }
 			for _, node := range tillEndOfBlock {
 				if isTerminatingStmt(pass, node) {
 					goto done
+				}
+			}
+
+			// The last attempt is to find partitioned but connected blocks that
+			// might have return statements or terminating statements in them.
+			// In this case, let's retrieve all the block indices accessible after we fall through
+			// this block or in the next/larger scope e.g.
+			// if errors.Is(err, os.ErrNotExist) {
+			// 	http.NotFound(rw, req)
+			// } else {
+			// 	http.Error(rw, "cannot load archive", 500)
+			// }
+			// return
+
+			for _, index := range partitionedButConnectedBlocks[block.Index] {
+				// Does the block have a return statement.
+				blocksToExplore := []*cfg.Block{acfg.Blocks[index]}
+				if false {
+					for _, subIndex := range partitionedButConnectedBlocks[index] {
+						blocksToExplore = append(blocksToExplore, acfg.Blocks[subIndex])
+					}
+				}
+				for _, cBlock := range blocksToExplore {
+					if cBlock.Return() != nil {
+						goto done
+					}
+					// Now check if any of the nodes in there have terminating statements.
+					for _, node := range cBlock.Nodes {
+						if isTerminatingStmt(pass, node) {
+							goto done
+						}
+					}
 				}
 			}
 
@@ -148,6 +206,19 @@ func responseWriterInParams(pass *analysis.Pass, fnDecl *ast.FuncDecl) bool {
 		}
 	}
 	return false
+}
+
+type incidence map[int32][]int32
+
+// buildIncidence traverses a block's successive neighbors, using explorable as a guide
+// for a well partitioned directed graph.
+func buildIncidence(discover *cfg.Block, explorable map[int32]bool, ind incidence) {
+	for _, succ := range discover.Succs {
+		if explorable[succ.Index] {
+			ind[discover.Index] = append(ind[discover.Index], succ.Index)
+			buildIncidence(succ, explorable, ind)
+		}
+	}
 }
 
 func isTerminatingStmt(pass *analysis.Pass, n ast.Node) bool {

--- a/httperroryzer_test.go
+++ b/httperroryzer_test.go
@@ -22,5 +22,5 @@ import (
 
 func Test(t *testing.T) {
 	testdata := analysistest.TestData()
-	analysistest.Run(t, testdata, Analyzer, "a")
+	analysistest.Run(t, testdata, Analyzer, "a", "b")
 }

--- a/sample/it_test.go
+++ b/sample/it_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAuthenticate(t *testing.T) {
+	tests := []struct {
+		name    string
+		secret  string
+		wantErr bool
+	}{
+		{
+			name:    "empty",
+			wantErr: true,
+		},
+		{
+			name:    "whitespace",
+			secret:  " ",
+			wantErr: true,
+		},
+		{
+			name:    "mismatched secret",
+			secret:  "not-the-secret",
+			wantErr: true,
+		},
+		{
+			name:   "proper secret",
+			secret: "open-sesame",
+		},
+	}
+
+	cst := httptest.NewServer(http.HandlerFunc(authenticate))
+	defer cst.Close()
+
+	client := cst.Client()
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", cst.URL, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("x-secret", tt.secret)
+			res, err := client.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			blob, err := ioutil.ReadAll(res.Body)
+			res.Body.Close()
+			if err != nil {
+				t.Fatal(err)
+			}
+			switch tt.wantErr {
+			case true:
+				if g, w := res.StatusCode, http.StatusUnauthorized; g != w {
+					t.Errorf("StatusCode mismatch:\nGot: %q\nWant statusCode: %d", res.Status, w)
+				}
+				if !bytes.Contains(blob, []byte("unauthorized")) {
+					t.Errorf(`Missing "unauthorized", got %q`, blob)
+				}
+
+			default:
+				if g, w := res.StatusCode, http.StatusOK; g != w {
+					t.Errorf("StatusCode mismatch:\nGot:  %q\nWant: %q", g, w)
+				}
+				if !bytes.Contains(blob, []byte(`"secret_location":`)) {
+					t.Errorf(`Body does not contain "secret_location", got %q`, blob)
+				}
+			}
+		})
+	}
+}

--- a/testdata/src/b/b.go
+++ b/testdata/src/b/b.go
@@ -1,0 +1,66 @@
+package a
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func proxyHandleWithoutReturn(rw http.ResponseWriter, req *http.Request) {
+	if err := do(); err != nil {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "go proxy: no archive: %v\n", err)
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			http.NotFound(rw, req)
+		} else {
+			http.Error(rw, "cannot load archive", 500) // want "call to http.Error without a terminating statement below it"
+		}
+		if req.Header.Get("Content-Type") != "video/mp4" {
+			if req.Header.Get("X-Auth-Token") != "open-sesame" {
+				if req.Header.Get("Origin") != "/home" {
+					http.Error(rw, "non-matching incarnation for the video", http.StatusBadRequest) // want "call to http.Error without a terminating.+"
+				}
+			}
+		}
+	}
+
+	ext := req.Header.Get("x-ext")
+	switch ext {
+	case "zip":
+		rw.Write([]byte("Zip here"))
+	}
+}
+
+func proxyHandleWithReturn(rw http.ResponseWriter, req *http.Request) {
+	if err := do(); err != nil {
+		if testing.Verbose() {
+			fmt.Fprintf(os.Stderr, "go proxy: no archive: %v\n", err)
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			http.NotFound(rw, req)
+		} else {
+			http.Error(rw, "cannot load archive", 500) // want "call to http.Error without a terminating.+"
+		}
+		if req.Header.Get("Content-Type") != "video/mp4" {
+			if req.Header.Get("X-Auth-Token") != "open-sesame" {
+				if req.Header.Get("Origin") != "/home" {
+					http.Error(rw, "non-matching incarnation for the video", http.StatusBadRequest)
+				}
+			}
+		}
+		return
+	}
+
+	ext := req.Header.Get("x-ext")
+	switch ext {
+	case "zip":
+		rw.Write([]byte("Zip here"))
+	}
+}
+
+func do() error {
+	return errors.New("foo")
+}


### PR DESCRIPTION
For cases in which the return is in the larger scope,
for this case we need to firstly ensure we create partitions
of elements and then find the appropriate end paths and check
if they end in terminating statements.

More work to follow.