### PR TITLE
all: detect diverse nested http.Error + misuse of http.NotFound too

### DIFF
--- a/testdata/src/b/b.go
+++ b/testdata/src/b/b.go
@@ -14,7 +14,7 @@ func proxyHandleWithoutReturn(rw http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(os.Stderr, "go proxy: no archive: %v\n", err)
 		}
 		if errors.Is(err, os.ErrNotExist) {
-			http.NotFound(rw, req)
+			http.NotFound(rw, req) // want "call to http.Error without a terminating statement below it"
 		} else {
 			http.Error(rw, "cannot load archive", 500) // want "call to http.Error without a terminating statement below it"
 		}
@@ -40,7 +40,7 @@ func proxyHandleWithReturn(rw http.ResponseWriter, req *http.Request) {
 			fmt.Fprintf(os.Stderr, "go proxy: no archive: %v\n", err)
 		}
 		if errors.Is(err, os.ErrNotExist) {
-			http.NotFound(rw, req)
+			http.NotFound(rw, req) // want "call to http.Error without a terminating statement below it"
 		} else {
 			http.Error(rw, "cannot load archive", 500) // want "call to http.Error without a terminating.+"
 		}
@@ -58,6 +58,41 @@ func proxyHandleWithReturn(rw http.ResponseWriter, req *http.Request) {
 	switch ext {
 	case "zip":
 		rw.Write([]byte("Zip here"))
+	}
+}
+
+func notFoundReplier(rw http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("failalways") != "" {
+		http.NotFound(rw, req) // want "call to http.Error without a terminating.+"
+	}
+	rw.Write([]byte("FOO"))
+}
+
+func notFoundReplierWithReturn(rw http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("failalways") != "" {
+		http.NotFound(rw, req)
+		return
+	}
+	rw.Write([]byte("FOO"))
+}
+
+func foo(rw http.ResponseWriter, req *http.Request) {
+	http.Error(rw, "msg", 404)
+}
+
+func notFoundReplierWithoutReturn(rw http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("failalways") != "" {
+		http.NotFound(rw, req)
+	}
+}
+
+func notFoundReplierWithBranch(rw http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("failalways") != "" {
+		rw.WriteHeader(200)
+		http.NotFound(rw, req)
+		rw.Write([]byte("fizz buzz"))
+	} else {
+		http.Error(rw, "ditto", http.StatusBadRequest)
 	}
 }
 


### PR DESCRIPTION
With this change, we simplify the code radically, no need to construct
an incidence matrix, but instead, on failing to find a terminating
statement within a block, we'll now walk each block's successors, and
if there is any statement that's not a defer nor a terminating statement,
report that error.